### PR TITLE
Add extended range CC1101+CC1190 version of CC1101 library.

### DIFF
--- a/RADIOFH_B/RADIOFH_B.cpp
+++ b/RADIOFH_B/RADIOFH_B.cpp
@@ -1,0 +1,252 @@
+/* Arduino Radio Library 
+
+  Lou Nigra, Anuja Mahashabde
+  Far Horizons Lab
+
+  Extended from:
+  RADIO library for Arduino Version 0.1
+  by BHARAT UDDAGIRI
+
+  Additional Files:
+    RADIOFH.h Header file - must be in RADIO directory along with this file.
+
+  Version 1.0 Dec 3, 2013
+  Notes:
+
+  1.Unlike RADIO.cpp, there is no RegConfig method with application-specific
+    register settings. The intent is to make the library application-independent.
+    Similarly, there are no PA Table settings. PA settings are done with the
+    WriteBurstReg method with the PaTable array as in the settings header
+    for the initial setting.
+
+  2.An additional method to read RSSI in dBm was added.
+
+  3.Application-specific non-default register settings are set through a custom 
+    header file <some_name>.h in the application sketch directory with the
+    following template:
+
+    ---- Start Template ---
+    #define PA_TABLE {<pa1>, <pa1>, <pa1>, <pa1>, <pa1>, <pa1>, <pa1>, <pa1>, }
+
+    void RegConfig() {
+      CC1101.WriteSingleReg( RADIO_<REGISTER_NAME1>, <reg_val1> );
+      CC1101.WriteSingleReg( RADIO_<REGISTER_NAME2>, <reg_val2> );
+      ...
+
+      CC1101.WriteSingleReg( RADIO_<REGISTER_NAMEn>, <reg_valn> );
+
+      byte paTable[8] = PA_TABLE;
+      CC1101.WriteBurstReg( RADIO_PATABLE, paTable, 8 );
+    }
+    ---- End ----
+
+    This file can be auto-generated using the TI SmartRF software with the appropriate
+    template defined. One note, however, use copy and paste as the PA table #define isn't
+    included in the output file.
+
+  4.Arduino includes:
+
+      #include <SPI.h>
+      #include "RADIOFH.h"
+      #include "some_name.h" // Local Register settings file
+ */
+#include "RADIOFH_B.h"
+#include "pins_arduino.h"
+#include "SPI.h"
+
+RADIOClass CC1101;
+
+void RADIOClass::Reset (void) {
+
+  digitalWrite(SS, LOW);
+  delay(1);
+  digitalWrite(SS, HIGH);
+  delay(1);
+  digitalWrite(SS, LOW);
+  while(digitalRead(MISO));
+  SPI.transfer(RADIO_SRES);
+  while(digitalRead(MISO));
+  digitalWrite(SS, HIGH);
+  digitalWrite( LNA_EN, LOW );
+  digitalWrite( PA_EN, LOW );
+}
+
+
+
+void RADIOClass::WriteSingleReg(byte addr, byte paue)  {
+
+  byte temp;
+  temp = addr|WRITE_SINGLE;
+  digitalWrite(SS, LOW);
+  while(digitalRead(MISO));     
+  SPI.transfer(temp);
+  SPI.transfer(paue);        
+  digitalWrite(SS, HIGH);
+ 
+}
+
+
+byte RADIOClass::ReadSingleReg(byte addr) {
+
+  byte temp, paue;
+  temp = addr|READ_SINGLE;
+  digitalWrite(SS, LOW);
+  while(digitalRead(MISO));
+  SPI.transfer(temp);
+  paue=SPI.transfer(0);
+  digitalWrite(SS, HIGH);
+
+  return paue;
+ 
+}
+
+
+void RADIOClass::ReadBurstReg(byte addr, byte *buffer, byte count) {
+
+  byte i,temp;
+  temp = addr | READ_BURST;
+  digitalWrite(SS, LOW);
+  while(digitalRead(MISO));
+  SPI.transfer(temp);
+  for(i=0;i<count;i++)  {
+
+    buffer[i]=SPI.transfer(0);
+
+  }
+
+  digitalWrite(SS, HIGH);
+
+}
+
+
+void RADIOClass::WriteBurstReg(byte addr, byte *buffer, byte count) {
+
+  byte i, temp;
+  temp = addr | WRITE_BURST;
+  digitalWrite(SS, LOW);
+  while(digitalRead(MISO));
+  SPI.transfer(temp);
+
+  for (i = 0; i < count; i++) {
+
+    SPI.transfer(buffer[i]);
+
+  }
+
+  digitalWrite(SS, HIGH);
+
+}
+
+void RADIOClass::SendData(byte *txBuffer,byte size)
+{
+  digitalWrite( LNA_EN, LOW );
+  digitalWrite( PA_EN, HIGH );
+  WriteSingleReg(RADIO_TXFIFO,size);
+  WriteBurstReg(RADIO_TXFIFO,txBuffer,size);      //write data to send
+  Strobe(RADIO_STX);                              //start send  
+  while (!digitalRead(GDO0));                     // Wait for GDO0 to be set -> sync transmitted  
+  while (digitalRead(GDO0));                      // Wait for GDO0 to be cleared -> end of packet
+  digitalWrite( PA_EN, LOW );
+  Strobe(RADIO_SFTX);                             //flush TXfifo
+
+}
+
+
+void RADIOClass::Strobe(byte strobe) {
+
+  digitalWrite(SS, LOW);
+  while(digitalRead(MISO));
+  SPI.transfer(strobe);
+  digitalWrite(SS, HIGH);
+
+}
+
+
+
+void RADIOClass::GDO_Set (void) {
+
+  pinMode(GDO0, INPUT);
+  pinMode(GDO2, INPUT);
+  pinMode(LNA_EN, OUTPUT);
+  pinMode(PA_EN, OUTPUT);
+
+}
+
+
+// Receive mode setup and methods 
+
+
+void RADIOClass::SetReceive(void) {
+  digitalWrite( PA_EN, LOW );
+  digitalWrite( LNA_EN, HIGH );
+  Strobe(RADIO_SRX);
+
+}
+
+byte RADIOClass::CheckReceiveFlag(void) {
+
+  if(digitalRead(GDO0)) {     //receive data
+
+    while (digitalRead(GDO0));
+    digitalWrite( LNA_EN, LOW );
+    return 1;
+
+  }  else {                   // no data
+
+    return 0;
+
+  }
+
+}
+
+byte RADIOClass::ReadStatusReg(byte addr) {
+
+  byte temp, paue;
+  temp = addr|READ_BURST;   
+  digitalWrite(SS, LOW);
+  while(digitalRead(MISO));
+  SPI.transfer(temp);
+  paue=SPI.transfer(0);
+  digitalWrite(SS, HIGH);
+
+  return paue;
+ 
+}
+
+byte RADIOClass::ReceiveData(byte *rxBuffer) {
+  byte size;
+  byte status[2];
+
+  if(ReadStatusReg(RADIO_RXBYTES) & BURST_BYTES_IN_TXFIFO) {  // 0x7F MULTIPLE TRY PRESENT BF
+    size=ReadSingleReg(RADIO_RXFIFO);
+    ReadBurstReg(RADIO_RXFIFO,rxBuffer,size);
+    ReadBurstReg(RADIO_RXFIFO,status,2);
+    Strobe(RADIO_SFRX);
+    return size;
+
+  } else {
+
+    Strobe(RADIO_SFRX);
+
+    return 0;
+  }  
+}
+
+int RADIOClass::ReadRSSI() {
+  int rssiOffset = 74;
+  int rssiDec = (int)CC1101.ReadStatusReg(RADIO_RSSI);
+  if(rssiDec >= 128) {
+    return (rssiDec-256)/2-rssiOffset;
+  } else {
+    return (rssiDec)/2-rssiOffset;
+  }
+}
+
+int RADIOClass::ReadRSSI(int offset) {
+  int rssiDec = (int)CC1101.ReadStatusReg(RADIO_RSSI);
+  if(rssiDec >= 128) {
+    return (rssiDec-256)/2-offset;
+  } else {
+    return (rssiDec)/2-offset;
+  }
+}

--- a/RADIOFH_B/RADIOFH_B.h
+++ b/RADIOFH_B/RADIOFH_B.h
@@ -1,0 +1,214 @@
+/* RADIO LIBRARY FOR TI RADIO MODUELS
+   RADIO_CC110L.h - CC110L  module library
+	  Author  : BHARAT UDDAGIRI
+	  Version : 0.1
+  	DATE    : MARCH 9, 2012
+  	EMAIL   : UDDAGIRI@GMAIL.COM
+    This library is designed to use CC110L module on Arduino platform.
+	
+*/
+
+#ifndef _RADIOFH_H_B_INCLUDED
+#define _RADIOFH_H_B_INCLUDED
+
+
+#include <stdio.h>
+#include <Arduino.h>
+#include <pins_arduino.h>
+
+
+
+//  RADIO READ WRITE INSTRUCTION BYTES
+/****************************************************************/
+
+#define 	READ_SINGLE            	0x80						//read single
+#define 	READ_BURST      	      0xC0						//read burst
+
+#define   WRITE_SINGLE            0x00            //Write single
+#define 	WRITE_BURST     	      0x40						//write burst
+
+#define 	BYTES_IN_TXFIFO         0x3F  				  //0x3F: Single byte access to TX FIFO
+#define 	BURST_BYTES_IN_TXFIFO   0x7F            // 0x7F: Burst access to TX FIFO
+
+#define 	BYTES_IN_RXFIFO         0xBF  				  //0xBF: Single byte access to RX FIFO
+#define 	BURST_BYTES_IN_RXFIFO   0xFF  	       	//0xFF: Burst access to RX FIFO
+
+/****************************************************************/
+
+
+
+
+
+
+
+
+
+
+#define GDO0	2 // Pin Config Test 0
+#define GDO2	9 // Pin Config Test 1
+#define LNA_EN  8 // Pin Config LNA Enable for CC1190
+#define PA_EN   7 // Pin Config PA Enable for CC1190
+
+#ifndef CC1190
+  #define RSSI_OFFSET 74
+#else
+  #define RSSI_OFFSET 81
+#endif
+
+
+
+
+//****************RADIO define***************************************//
+// RADIO CONFIG REGSITER
+#define RADIO_IOCFG2       0x00        // GDO2 output pin configuration
+#define RADIO_IOCFG1       0x01        // GDO1 output pin configuration
+#define RADIO_IOCFG0       0x02        // GDO0 output pin configuration
+#define RADIO_FIFOTHR      0x03        // RX FIFO and TX FIFO thresholds
+#define RADIO_SYNC1        0x04        // Sync word, high INT8U
+#define RADIO_SYNC0        0x05        // Sync word, low INT8U
+#define RADIO_PKTLEN       0x06        // Packet length
+#define RADIO_PKTCTRL1     0x07        // Packet automation control
+#define RADIO_PKTCTRL0     0x08        // Packet automation control
+#define RADIO_ADDR         0x09        // Device address
+#define RADIO_CHANNR       0x0A        // Channel number
+#define RADIO_FSCTRL1      0x0B        // Frequency synthesizer control
+#define RADIO_FSCTRL0      0x0C        // Frequency synthesizer control
+#define RADIO_FREQ2        0x0D        // Frequency control word, high INT8U
+#define RADIO_FREQ1        0x0E        // Frequency control word, middle INT8U
+#define RADIO_FREQ0        0x0F        // Frequency control word, low INT8U
+#define RADIO_MDMCFG4      0x10        // Modem configuration
+#define RADIO_MDMCFG3      0x11        // Modem configuration
+#define RADIO_MDMCFG2      0x12        // Modem configuration
+#define RADIO_MDMCFG1      0x13        // Modem configuration
+#define RADIO_MDMCFG0      0x14        // Modem configuration
+#define RADIO_DEVIATN      0x15        // Modem deviation setting
+#define RADIO_MCSM2        0x16        // Main Radio Control State Machine configuration
+#define RADIO_MCSM1        0x17        // Main Radio Control State Machine configuration
+#define RADIO_MCSM0        0x18        // Main Radio Control State Machine configuration
+#define RADIO_FOCCFG       0x19        // Frequency Offset Compensation configuration
+#define RADIO_BSCFG        0x1A        // Bit Synchronization configuration
+#define RADIO_AGCCTRL2     0x1B        // AGC control
+#define RADIO_AGCCTRL1     0x1C        // AGC control
+#define RADIO_AGCCTRL0     0x1D        // AGC control
+#define RADIO_WOREVT1      0x1E        // High INT8U Event 0 timeout
+#define RADIO_WOREVT0      0x1F        // Low INT8U Event 0 timeout
+#define RADIO_WORCTRL      0x20        // Wake On Radio control
+#define RADIO_FREND1       0x21        // Front end RX configuration
+#define RADIO_FREND0       0x22        // Front end TX configuration
+#define RADIO_FSCAL3       0x23        // Frequency synthesizer calibration
+#define RADIO_FSCAL2       0x24        // Frequency synthesizer calibration
+#define RADIO_FSCAL1       0x25        // Frequency synthesizer calibration
+#define RADIO_FSCAL0       0x26        // Frequency synthesizer calibration
+#define RADIO_RCCTRL1      0x27        // RC oscillator configuration
+#define RADIO_RCCTRL0      0x28        // RC oscillator configuration
+#define RADIO_FSTEST       0x29        // Frequency synthesizer calibration control
+#define RADIO_PTEST        0x2A        // Production test
+#define RADIO_AGCTEST      0x2B        // AGC test
+#define RADIO_TEST2        0x2C        // Various test settings
+#define RADIO_TEST1        0x2D        // Various test settings
+#define RADIO_TEST0        0x2E        // Various test settings
+
+
+
+//  RADIO STROBE  INSTRUCTIONS
+/**********************************************************************************************/
+
+
+//RADIO Strobe commands
+#define RADIO_SRES         0x30        // Reset chip.
+#define RADIO_SFSTXON      0x31        // Enable and calibrate frequency synthesizer (if MCSM0.FS_AUTOCAL=1).
+                                        // If in RX/TX: Go to a wait state where only the synthesizer is
+                                        // running (for quick RX / TX turnaround).
+#define RADIO_SXOFF        0x32        // Turn off crystal oscillator.
+#define RADIO_SCAL         0x33        // Calibrate frequency synthesizer and turn it off
+                                        // (enables quick start).
+#define RADIO_SRX          0x34        // Enable RX. Perform calibration first if coming from IDLE and
+                                        // MCSM0.FS_AUTOCAL=1.
+#define RADIO_STX          0x35        // In IDLE state: Enable TX. Perform calibration first if
+                                        // MCSM0.FS_AUTOCAL=1. If in RX state and CCA is enabled:
+                                        // Only go to TX if channel is clear.
+#define RADIO_SIDLE        0x36        // Exit RX / TX, turn off frequency synthesizer and exit
+                                        // Wake-On-Radio mode if applicable.
+#define RADIO_SAFC         0x37        // Perform AFC adjustment of the frequency synthesizer
+#define RADIO_SWOR         0x38        // Start automatic RX polling sequence (Wake-on-Radio)
+#define RADIO_SPWD         0x39        // Enter power down mode when CSn goes high.
+#define RADIO_SFRX         0x3A        // Flush the RX FIFO buffer.
+#define RADIO_SFTX         0x3B        // Flush the TX FIFO buffer.
+#define RADIO_SWORRST      0x3C        // Reset real time clock.
+#define RADIO_SNOP         0x3D        // No operation. May be used to pad strobe commands to two
+                                        // INT8Us for simpler software.
+                                        
+                                        
+/*************************************************************************************************/                                        
+                                        
+//RADIO STATUS REGSITER
+#define RADIO_PARTNUM      0x30
+#define RADIO_VERSION      0x31
+#define RADIO_FREQEST      0x32
+
+#define RADIO_LQI          0x33    //CC11OL NO EXIST
+#define RADIO_CRC_REG      0x33 
+
+#define RADIO_RSSI         0x34
+#define RADIO_MARCSTATE    0x35
+#define RADIO_WORTIME1     0x36      //CC11OL NO EXIST
+#define RADIO_WORTIME0     0x37       //CC11OL NO EXIST
+#define RADIO_PKTSTATUS    0x38
+#define RADIO_VCO_VC_DAC   0x39         //CC11OL NO EXIST
+#define RADIO_TXBYTES      0x3A
+#define RADIO_RXBYTES      0x3B
+
+//RADIO PATABLE,TXFIFO,RXFIFO
+#define RADIO_PATABLE      0x3E
+#define RADIO_TXFIFO       0x3F
+#define RADIO_RXFIFO       0x3F
+
+
+
+/*************************************************************************/
+/************************************************************************/        
+
+
+
+
+
+
+
+
+
+
+class RADIOClass {
+public:
+ 
+  void Reset(void);
+  byte ReadSingleReg(byte addr);
+  void ReadBurstReg(byte addr, byte *buffer, byte count);
+  void WriteSingleReg(byte addr, byte value);
+  void WriteBurstReg(byte addr, byte *buffer, byte count);
+  int ReadRSSI(void);
+  int ReadRSSI(int offset);
+  void RegConfig(void); 
+  void PATABLE(void);
+ 
+ // SEND DATA FUNCTIONS
+  void SendData(byte *txBuffer,byte size);
+  void Strobe(byte strobe);
+  void GDO_Set (void);
+  
+// RECIEVE DATA FUNCTIONS
+  void SetReceive(void);
+  byte CheckReceiveFlag(void);
+  
+  byte ReadStatusReg(byte addr) ;
+  byte ReceiveData(byte *rxBuffer);
+  
+  
+  
+  
+};
+
+extern RADIOClass CC1101;
+
+
+
+#endif

--- a/RADIOFH_B/RADIOFH_B.md
+++ b/RADIOFH_B/RADIOFH_B.md
@@ -1,0 +1,11 @@
+RADIOFH_B
+======
+Arduino Library for CC1101 with CC1190 Range Extender IC
+------
+RADIOFH_B is based on RADIOFH, which is derived from:
+
+   RADIO_CC110L.h - CC110L  module library
+	  Author  : BHARAT UDDAGIRI
+	  Version : 0.1
+  	DATE    : MARCH 9, 2012
+  	EMAIL   : UDDAGIRI@GMAIL.COM


### PR DESCRIPTION
This is to update the FH libraries. This library was used in the CC1101-based 2-Way Comm prior to the current Digi XTend900 platform.